### PR TITLE
Add allErrors to validate request/response options

### DIFF
--- a/docs/usage-validate-requests.md
+++ b/docs/usage-validate-requests.md
@@ -7,9 +7,10 @@ Determines whether the validator should validate requests.
 !!! Option-Schema
     ```javascript
     validateRequests: true | false | {
-        allowUnknownQueryParameters
-        coerceTypes: false | true | 'array'
-        removeAdditional: false | true | 'all' | 'failing'
+        allowUnknownQueryParameters: false | true,
+        coerceTypes: false | true | 'array',
+        removeAdditional: false | true | 'all' | 'failing',
+        allErrors: false | true,
     }
     ```
 
@@ -24,11 +25,11 @@ Determines whether the validator should validate requests.
 
         Determines whether the validator will coerce the request body. Request query and path params, headers, cookies are coerced by default and this setting does not affect that.
 
-        See [additional details](assets/docs/coercion.md) on coercion and limitiations.
+        See [additional details](assets/docs/coercion.md) on coercion and limitations.
 
         **Option Schema**
         ```javascript
-        coerceTypes: false | true | 'array
+        coerceTypes: false | true | 'array'
         ```
 
         - `true` - coerce scalar data types.
@@ -41,8 +42,9 @@ Determines whether the validator should validate requests.
 
         **Option Schema**
         ```javascript
-        coerceTypes: false | true | 'array'
+        allowUnknownQueryParameters: false | true
         ```
+
         - `true` - enables unknown/undeclared query parameters to pass validation
         - `false` - (**default**) fail validation if an unknown query parameter is present
 
@@ -55,17 +57,17 @@ Determines whether the validator should validate requests.
 
             ```yaml
             paths:
-                /allow_unknown:
+              /allow_unknown:
                 get:
-                    x-allow-unknown-query-parameters: true   ## <--- overrides the global setting
-                    parameters:
+                  x-allow-unknown-query-parameters: true ## <--- overrides the global setting
+                  parameters:
                     - name: value
-                        in: query
-                        schema:
-                        type: string
-                    responses:
+                      in: query
+                      schema:
+                      type: string
+                  responses:
                     200:
-                        description: success
+                      description: success
             ```
 
     -  ### `removeAdditional`
@@ -74,9 +76,27 @@ Determines whether the validator should validate requests.
 
         **Option Schema**
         ```javascript
-        removeAdditional: false | true 'all' | 'failing'
+        removeAdditional: false | true | 'all' | 'failing'
         ```
+
         - `false` (**default**) - not to remove additional properties
         - `"all"` - all additional properties are removed, regardless of additionalProperties keyword in schema (and no validation is made for them).
         - `true` - only additional properties with additionalProperties keyword equal to false are removed.
         - `"failing"` - additional properties that fail request schema validation will be removed (where additionalProperties keyword is false or schema).
+
+    - ### `allErrors`
+
+        > This option was introduced in version 5.4.0, where the default behavior of request validation was changed to stop after the first failure.
+
+        Determine's whether all validation rules should be checked and all failures reported. By default, validation stops after the first failure. This option passes through to AJV, see [AJV Options: allErrors](https://ajv.js.org/options.html#allerrors).
+
+        **Do NOT use allErrors in production**  
+        Following the [recommended best practices by AJV](https://ajv.js.org/security.html#security-risks-of-trusted-schemas), this option should be left unset, or set to `false` in production to help mitigate slow validations and potential ReDOS attacks.
+
+        **Option Schema**
+        ```javascript
+        allErrors: false | true
+        ```
+
+        - `true` - all rules should be checked and all failures reported
+        - `false` - (**default**) stop checking rules after the first failure

--- a/docs/usage-validate-responses.md
+++ b/docs/usage-validate-responses.md
@@ -9,7 +9,8 @@ Determines whether the validator should validate responses. Additionally, it acc
     validateResponses: false | true | {
         removeAdditional: 'failing',
         coerceTypes: true | false | 'array',
-        onError: (error, body, req): void
+        onError: (error, body, req): void,
+        allErrors: false | true,
     }
     ```
 
@@ -50,3 +51,20 @@ Determines whether the validator should validate responses. Additionally, it acc
                 }
             }
             ```
+
+    - ### `allErrors`
+
+        > This option was introduced in version 5.4.0, where the default behavior of response validation was changed to stop after the first failure.
+
+        Determine's whether all validation rules should be checked and all failures reported. By default, validation stops after the first failure. This option passes through to AJV, see [AJV Options: allErrors](https://ajv.js.org/options.html#allerrors).
+
+        **Do NOT use allErrors in production**  
+        Following the [recommended best practices by AJV](https://ajv.js.org/security.html#security-risks-of-trusted-schemas), this option should be left unset, or set to `false` in production to help mitigate slow validations and potential ReDOS attacks.
+
+        **Option Schema**
+        ```javascript
+        allErrors: false | true
+        ```
+
+        - `true` - all rules should be checked and all failures reported
+        - `false` - (**default**) stop checking rules after the first failure


### PR DESCRIPTION
- Include usage notes and schema for `allErrors` property in `validateRequests` and `validateResponses`.
- Minor typo fixes.