### PR TITLE
Fix version where allErrors option was introduced

### DIFF
--- a/docs/usage-validate-requests.md
+++ b/docs/usage-validate-requests.md
@@ -86,7 +86,7 @@ Determines whether the validator should validate requests.
 
     - ### `allErrors`
 
-        > This option was introduced in version 5.4.0, where the default behavior of request validation was changed to stop after the first failure.
+        > This option was introduced in version 5.3.4, where the default behavior of request validation was changed to stop after the first failure.
 
         Determine's whether all validation rules should be checked and all failures reported. By default, validation stops after the first failure. This option passes through to AJV, see [AJV Options: allErrors](https://ajv.js.org/options.html#allerrors).
 

--- a/docs/usage-validate-responses.md
+++ b/docs/usage-validate-responses.md
@@ -54,7 +54,7 @@ Determines whether the validator should validate responses. Additionally, it acc
 
     - ### `allErrors`
 
-        > This option was introduced in version 5.4.0, where the default behavior of response validation was changed to stop after the first failure.
+        > This option was introduced in version 5.3.4, where the default behavior of response validation was changed to stop after the first failure.
 
         Determine's whether all validation rules should be checked and all failures reported. By default, validation stops after the first failure. This option passes through to AJV, see [AJV Options: allErrors](https://ajv.js.org/options.html#allerrors).
 


### PR DESCRIPTION
Options `validateRequests.allErrors` and `validateResponses.allErrors` were introduced in version 5.3.4:
https://github.com/cdimascio/express-openapi-validator/releases/tag/v5.3.4